### PR TITLE
Let's take this library up to 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+- Add 5-10 arguments implementation
+
 ## 1.2.0
 - Add 4 arguments implementation
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ void main() {
   print(func(rect2)); // not cached - different object instance
 }
 ```
+
+## Contributors
+
+  - [Brian Egan](https://gitlab.com/users/brianegan/projects)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Examples
 
-`memo1`, `memo2`, `memo3`, `memo4` compare arguments with `==` operator:
+`memo1`, `memo2`, ... `memo10` compare arguments with `==` operator:
 
 
 ```dart
@@ -22,7 +22,7 @@ void main() {
 }
 ```
 
-`imemo1`, `imemo2`, `imemo3`, `imemo4` compare arguments with `identical` function:
+`imemo1`, `imemo2`, ... `imemo10` compare arguments with `identical` function:
 
 ```dart
 import 'dart:math';

--- a/lib/memoize.dart
+++ b/lib/memoize.dart
@@ -1,6 +1,7 @@
 import 'package:func/func.dart';
 
-/// Checks 1 argument for equality with [==] operator and returns cached result if it was not changed.
+/// Checks 1 argument for equality with [==] operator and returns the cached
+/// result if it was not changed.
 Func1<A, R> memo1<A, R>(Func1<A, R> func) {
   A prevArg;
   R prevResult;
@@ -19,20 +20,21 @@ Func1<A, R> memo1<A, R>(Func1<A, R> func) {
   });
 }
 
-/// Checks 2 arguments for equality with [==] operator and returns cached result if they were not changed.
+/// Checks 2 arguments for equality with [==] operator and returns the cached
+/// result if they were not changed.
 Func2<A, B, R> memo2<A, B, R>(Func2<A, B, R> func) {
-  A prevArg1;
-  B prevArg2;
+  A prevArgA;
+  B prevArgB;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2) {
-    if (!isInitial && arg1 == prevArg1 && arg2 == prevArg2) {
+  return ((A argA, B argB) {
+    if (!isInitial && argA == prevArgA && argB == prevArgB) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevResult = func(arg1, arg2);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevResult = func(argA, argB);
       isInitial = false;
 
       return prevResult;
@@ -40,22 +42,26 @@ Func2<A, B, R> memo2<A, B, R>(Func2<A, B, R> func) {
   });
 }
 
-/// Checks 3 arguments for equality with [==] operator and returns cached result if they were not changed.
+/// Checks 3 arguments for equality with [==] operator and returns the cached
+/// result if they were not changed.
 Func3<A, B, C, R> memo3<A, B, C, R>(Func3<A, B, C, R> func) {
-  A prevArg1;
-  B prevArg2;
-  C prevArg3;
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2, C arg3) {
-    if (!isInitial && arg1 == prevArg1 && arg2 == prevArg2 && arg3 == prevArg3) {
+  return ((A argA, B argB, C argC) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevArg3 = arg3;
-      prevResult = func(arg1, arg2, arg3);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevResult = func(argA, argB, argC);
       isInitial = false;
 
       return prevResult;
@@ -63,24 +69,29 @@ Func3<A, B, C, R> memo3<A, B, C, R>(Func3<A, B, C, R> func) {
   });
 }
 
-/// Checks 4 arguments for equality with [==] operator and returns cached result if they were not changed.
+/// Checks 4 arguments for equality with [==] operator and returns the cached
+/// result if they were not changed.
 Func4<A, B, C, D, R> memo4<A, B, C, D, R>(Func4<A, B, C, D, R> func) {
-  A prevArg1;
-  B prevArg2;
-  C prevArg3;
-  D prevArg4;
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2, C arg3, D arg4) {
-    if (!isInitial && arg1 == prevArg1 && arg2 == prevArg2 && arg3 == prevArg3 && arg4 == prevArg4) {
+  return ((A argA, B argB, C argC, D argD) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevArg3 = arg3;
-      prevArg4 = arg4;
-      prevResult = func(arg1, arg2, arg3, arg4);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevResult = func(argA, argB, argC, argD);
       isInitial = false;
 
       return prevResult;
@@ -88,7 +99,259 @@ Func4<A, B, C, D, R> memo4<A, B, C, D, R>(Func4<A, B, C, D, R> func) {
   });
 }
 
-/// Checks 1 argument for equality with [identical] call and returns cached result if it was not changed.
+/// Checks 5 arguments for equality with [==] operator and returns the cached
+/// result if it was not changed.
+Func5<A, B, C, D, E, R> memo5<A, B, C, D, E, R>(Func5<A, B, C, D, E, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevResult = func(argA, argB, argC, argD, argE);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 6 arguments for equality with [==] operator and returns the cached
+/// result if it was not changed.
+Func6<A, B, C, D, E, F, R> memo6<A, B, C, D, E, F, R>(
+    Func6<A, B, C, D, E, F, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE &&
+        argF == prevArgF) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevResult = func(argA, argB, argC, argD, argE, argF);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 7 arguments for equality with [==] operator and returns the cached
+/// result if it was not changed.
+Func7<A, B, C, D, E, F, G, R> memo7<A, B, C, D, E, F, G, R>(
+    Func7<A, B, C, D, E, F, G, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE &&
+        argF == prevArgF &&
+        argG == prevArgG) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 8 arguments for equality with [==] operator and returns the cached
+/// result if it was not changed.
+Func8<A, B, C, D, E, F, G, H, R> memo8<A, B, C, D, E, F, G, H, R>(
+    Func8<A, B, C, D, E, F, G, H, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE &&
+        argF == prevArgF &&
+        argG == prevArgG &&
+        argH == prevArgH) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG, argH);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 9 arguments for equality with [==] operator and returns the cached
+/// result if it was not changed.
+Func9<A, B, C, D, E, F, G, H, I, R> memo9<A, B, C, D, E, F, G, H, I, R>(
+    Func9<A, B, C, D, E, F, G, H, I, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  I prevArgI;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH,
+      I argI) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE &&
+        argF == prevArgF &&
+        argG == prevArgG &&
+        argH == prevArgH &&
+        argI == prevArgI) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevArgI = argI;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG, argH, argI);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 10 arguments for equality with [==] operator and returns cached
+/// result if it was not changed.
+Func10<A, B, C, D, E, F, G, H, I, J, R> memo10<A, B, C, D, E, F, G, H, I, J, R>(
+    Func10<A, B, C, D, E, F, G, H, I, J, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  I prevArgI;
+  J prevArgJ;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH,
+      I argI, J argJ) {
+    if (!isInitial &&
+        argA == prevArgA &&
+        argB == prevArgB &&
+        argC == prevArgC &&
+        argD == prevArgD &&
+        argE == prevArgE &&
+        argF == prevArgF &&
+        argG == prevArgG &&
+        argH == prevArgH &&
+        argI == prevArgI &&
+        argJ == prevArgJ) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevArgI = argI;
+      prevArgJ = argJ;
+      prevResult =
+          func(argA, argB, argC, argD, argE, argF, argG, argH, argI, argJ);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 1 argument for equality with [identical] call and returns the cached
+/// result if it was not changed.
 Func1<A, R> imemo1<A, R>(Func1<A, R> func) {
   A prevArg;
   R prevResult;
@@ -107,20 +370,21 @@ Func1<A, R> imemo1<A, R>(Func1<A, R> func) {
   });
 }
 
-/// Checks 2 arguments for equality with [identical] call and returns cached result if they were not changed.
+/// Checks 2 arguments for equality with [identical] call and returns the cached
+/// result if they were not changed.
 Func2<A, B, R> imemo2<A, B, R>(Func2<A, B, R> func) {
-  A prevArg1;
-  B prevArg2;
+  A prevArgA;
+  B prevArgB;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2) {
-    if (!isInitial && identical(arg1, prevArg1) && identical(arg2, prevArg2)) {
+  return ((A argA, B argB) {
+    if (!isInitial && identical(argA, prevArgA) && identical(argB, prevArgB)) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevResult = func(arg1, arg2);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevResult = func(argA, argB);
       isInitial = false;
 
       return prevResult;
@@ -128,22 +392,26 @@ Func2<A, B, R> imemo2<A, B, R>(Func2<A, B, R> func) {
   });
 }
 
-/// Checks 3 arguments for equality with [identical] call and returns cached result if they were not changed.
+/// Checks 3 arguments for equality with [identical] call and returns the cached
+/// result if they were not changed.
 Func3<A, B, C, R> imemo3<A, B, C, R>(Func3<A, B, C, R> func) {
-  A prevArg1;
-  B prevArg2;
-  C prevArg3;
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2, C arg3) {
-    if (!isInitial && identical(arg1, prevArg1) && identical(arg2, prevArg2) && identical(arg3, prevArg3)) {
+  return ((A argA, B argB, C argC) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC)) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevArg3 = arg3;
-      prevResult = func(arg1, arg2, arg3);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevResult = func(argA, argB, argC);
       isInitial = false;
 
       return prevResult;
@@ -151,26 +419,281 @@ Func3<A, B, C, R> imemo3<A, B, C, R>(Func3<A, B, C, R> func) {
   });
 }
 
-/// Checks 4 arguments for equality with [identical] call and returns cached result if they were not changed.
+/// Checks 4 arguments for equality with [identical] call and returns the cached
+/// result if they were not changed.
 Func4<A, B, C, D, R> imemo4<A, B, C, D, R>(Func4<A, B, C, D, R> func) {
-  A prevArg1;
-  B prevArg2;
-  C prevArg3;
-  D prevArg4;
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
   R prevResult;
   bool isInitial = true;
 
-  return ((A arg1, B arg2, C arg3, D arg4) {
+  return ((A argA, B argB, C argC, D argD) {
     if (!isInitial &&
-      identical(arg1, prevArg1) && identical(arg2, prevArg2) &&
-      identical(arg3, prevArg3) && identical(arg4, prevArg4)) {
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD)) {
       return prevResult;
     } else {
-      prevArg1 = arg1;
-      prevArg2 = arg2;
-      prevArg3 = arg3;
-      prevArg4 = arg4;
-      prevResult = func(arg1, arg2, arg3, arg4);
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevResult = func(argA, argB, argC, argD);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 5 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func5<A, B, C, D, E, R> imemo5<A, B, C, D, E, R>(Func5<A, B, C, D, E, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevResult = func(argA, argB, argC, argD, argE);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 6 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func6<A, B, C, D, E, F, R> imemo6<A, B, C, D, E, F, R>(
+    Func6<A, B, C, D, E, F, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE) &&
+        identical(argF, prevArgF)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevResult = func(argA, argB, argC, argD, argE, argF);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 7 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func7<A, B, C, D, E, F, G, R> imemo7<A, B, C, D, E, F, G, R>(
+    Func7<A, B, C, D, E, F, G, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE) &&
+        identical(argF, prevArgF) &&
+        identical(argG, prevArgG)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 8 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func8<A, B, C, D, E, F, G, H, R> imemo8<A, B, C, D, E, F, G, H, R>(
+    Func8<A, B, C, D, E, F, G, H, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE) &&
+        identical(argF, prevArgF) &&
+        identical(argG, prevArgG) &&
+        identical(argH, prevArgH)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG, argH);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 9 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func9<A, B, C, D, E, F, G, H, I, R> imemo9<A, B, C, D, E, F, G, H, I, R>(
+    Func9<A, B, C, D, E, F, G, H, I, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  I prevArgI;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH,
+      I argI) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE) &&
+        identical(argF, prevArgF) &&
+        identical(argG, prevArgG) &&
+        identical(argH, prevArgH) &&
+        identical(argI, prevArgI)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevArgI = argI;
+      prevResult = func(argA, argB, argC, argD, argE, argF, argG, argH, argI);
+      isInitial = false;
+
+      return prevResult;
+    }
+  });
+}
+
+/// Checks 10 arguments for equality with [identical] call and returns cached
+/// result if they were not changed.
+Func10<A, B, C, D, E, F, G, H, I, J, R>
+    imemo10<A, B, C, D, E, F, G, H, I, J, R>(
+        Func10<A, B, C, D, E, F, G, H, I, J, R> func) {
+  A prevArgA;
+  B prevArgB;
+  C prevArgC;
+  D prevArgD;
+  E prevArgE;
+  F prevArgF;
+  G prevArgG;
+  H prevArgH;
+  I prevArgI;
+  J prevArgJ;
+  R prevResult;
+  bool isInitial = true;
+
+  return ((A argA, B argB, C argC, D argD, E argE, F argF, G argG, H argH,
+      I argI, J argJ) {
+    if (!isInitial &&
+        identical(argA, prevArgA) &&
+        identical(argB, prevArgB) &&
+        identical(argC, prevArgC) &&
+        identical(argD, prevArgD) &&
+        identical(argE, prevArgE) &&
+        identical(argF, prevArgF) &&
+        identical(argG, prevArgG) &&
+        identical(argH, prevArgH) &&
+        identical(argI, prevArgI) &&
+        identical(argJ, prevArgJ)) {
+      return prevResult;
+    } else {
+      prevArgA = argA;
+      prevArgB = argB;
+      prevArgC = argC;
+      prevArgD = argD;
+      prevArgE = argE;
+      prevArgF = argF;
+      prevArgG = argG;
+      prevArgH = argH;
+      prevArgI = argI;
+      prevArgJ = argJ;
+      prevResult =
+          func(argA, argB, argC, argD, argE, argF, argG, argH, argI, argJ);
       isInitial = false;
 
       return prevResult;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=1.21.0 <2.0.0'
 
 dependencies:
-  func: ^0.1.1
+  func: ">=1.0.0 <2.0.0"
 
 dev_dependencies:
-  test: ^0.12.15+2
+  test: 0.12.24+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: memoize
-version: 1.2.0
+version: 1.3.0
 description: Returns cached result of function call when inputs were not changed from previous invocation.
 
 authors:

--- a/test/memoize_test.dart
+++ b/test/memoize_test.dart
@@ -206,7 +206,8 @@ void main() {
 
     test('should check arguments by reference', () {
       var count = 0;
-      var func = memo3((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c) => ++count);
+      var func = memo3(
+          (Rectangle<int> a, Rectangle<int> b, Rectangle<int> c) => ++count);
 
       var rect1 = new Rectangle<int>(0, 0, 10, 20);
       var rect2 = new Rectangle<int>(0, 0, 10, 20);
@@ -250,7 +251,8 @@ void main() {
 
     test('should check arguments by reference', () {
       var count = 0;
-      var func = imemo3((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c) => ++count);
+      var func = imemo3(
+          (Rectangle<int> a, Rectangle<int> b, Rectangle<int> c) => ++count);
 
       var rect1 = new Rectangle<int>(0, 0, 10, 20);
       var rect2 = new Rectangle<int>(0, 0, 10, 20);
@@ -295,7 +297,9 @@ void main() {
 
     test('should check arguments by value', () {
       var count = 0;
-      var func = memo4((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c, Rectangle<int> d) => ++count);
+      var func = memo4((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d) =>
+          ++count);
 
       var rect1 = new Rectangle<int>(0, 0, 10, 20);
       var rect2 = new Rectangle<int>(0, 0, 10, 20);
@@ -343,7 +347,9 @@ void main() {
 
     test('should check arguments by reference', () {
       var count = 0;
-      var func = imemo4((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c, Rectangle<int> d) => ++count);
+      var func = imemo4((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d) =>
+          ++count);
 
       var rect1 = new Rectangle<int>(0, 0, 10, 20);
       var rect2 = new Rectangle<int>(0, 0, 10, 20);
@@ -361,6 +367,798 @@ void main() {
       expect(func(rect1, rect2, rect3, rect4), 6);
       expect(func(rect1, rect2, rect3, rect5), 7);
       expect(func(rect1, rect2, rect3, rect5), 7);
+    });
+  });
+
+  group('memo5', () {
+    test('should cache result for 5 arguments', () {
+      var count = 0;
+      var func = memo5((int a, int b, int c, int d, int e) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null), 1);
+      expect(func(null, null, null, null, 5), 2);
+      expect(func(null, null, null, 4, 5), 3);
+      expect(func(null, null, 3, 4, 5), 4);
+      expect(func(null, 2, 3, 4, 5), 5);
+      expect(func(1, 2, 3, 4, 5), 6);
+      expect(func(1, 2, 3, 4, 5), 6);
+    });
+
+    test('should return result for 5 arguments', () {
+      var func =
+          memo5((int a, int b, int c, int d, int e) => a + b + c + d + e);
+
+      expect(func(1, 1, 1, 1, 1), 5);
+      expect(func(1, 1, 1, 1, 5), 9);
+      expect(func(1, 1, 1, 4, 5), 12);
+      expect(func(1, 1, 3, 4, 5), 14);
+      expect(func(1, 2, 3, 4, 5), 15);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo5((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d, Rectangle<int> e) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect2), 1);
+      expect(func(rect2, rect2, rect3, rect3, rect1), 1);
+      expect(func(rect1, rect3, rect3, rect4, rect3), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect4), 1);
+      expect(func(rect2, rect2, rect3, rect1, rect1), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5), 1);
+      expect(func(rect4, rect2, rect3, rect5, rect6), 2);
+      expect(func(rect1, rect2, rect3, rect5, rect6), 2);
+    });
+  });
+
+  group('imemo5', () {
+    test('should cache result for 5 arguments', () {
+      var count = 0;
+      var func = imemo5((int a, int b, int c, int d, int e) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null), 1);
+      expect(func(null, null, null, null, 5), 2);
+      expect(func(null, null, null, 4, 5), 3);
+      expect(func(null, null, 3, 4, 5), 4);
+      expect(func(null, 2, 3, 4, 5), 5);
+      expect(func(1, 2, 3, 4, 5), 6);
+      expect(func(1, 2, 3, 4, 5), 6);
+    });
+
+    test('should return result for 5 arguments', () {
+      var func =
+          imemo5((int a, int b, int c, int d, int e) => a + b + c + d + e);
+
+      expect(func(1, 1, 1, 1, 1), 5);
+      expect(func(1, 1, 1, 1, 5), 9);
+      expect(func(1, 1, 1, 4, 5), 12);
+      expect(func(1, 1, 3, 4, 5), 14);
+      expect(func(1, 2, 3, 4, 5), 15);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo5((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d, Rectangle<int> e) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5), 1);
+      expect(func(rect2, rect2, rect3, rect3, rect1), 2);
+      expect(func(rect1, rect3, rect3, rect4, rect3), 3);
+      expect(func(rect1, rect2, rect3, rect4, rect4), 4);
+      expect(func(rect2, rect2, rect3, rect1, rect1), 5);
+      expect(func(rect1, rect2, rect3, rect4, rect5), 6);
+      expect(func(rect1, rect2, rect3, rect5, rect6), 7);
+      expect(func(rect1, rect2, rect3, rect5, rect6), 7);
+    });
+  });
+
+  group('memo6', () {
+    test('should cache result for 6 arguments', () {
+      var count = 0;
+      var func = memo6((int a, int b, int c, int d, int e, int f) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, 6), 2);
+      expect(func(null, null, null, null, 5, 6), 3);
+      expect(func(null, null, null, 4, 5, 6), 4);
+      expect(func(null, null, 3, 4, 5, 6), 5);
+      expect(func(null, 2, 3, 4, 5, 6), 6);
+      expect(func(1, 2, 3, 4, 5, 6), 7);
+      expect(func(1, 2, 3, 4, 5, 6), 7);
+    });
+
+    test('should return result for 6 arguments', () {
+      var func = memo6(
+          (int a, int b, int c, int d, int e, int f) => a + b + c + d + e + f);
+
+      expect(func(1, 1, 1, 1, 1, 1), 6);
+      expect(func(1, 1, 1, 1, 1, 2), 7);
+      expect(func(1, 1, 1, 1, 2, 2), 8);
+      expect(func(1, 1, 1, 2, 2, 2), 9);
+      expect(func(1, 1, 2, 2, 2, 2), 10);
+      expect(func(1, 2, 2, 2, 2, 2), 11);
+      expect(func(2, 2, 2, 2, 2, 2), 12);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo6((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d, Rectangle<int> e, Rectangle<int> f) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect6), 1);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1), 1);
+      expect(func(rect1, rect3, rect3, rect4, rect3, rect3), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect4), 1);
+      expect(func(rect2, rect2, rect3, rect1, rect1, rect1), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect1, rect5), 1);
+      expect(func(rect4, rect2, rect3, rect5, rect2, rect7), 2);
+      expect(func(rect1, rect2, rect3, rect5, rect2, rect7), 2);
+    });
+  });
+
+  group('imemo6', () {
+    test('should cache result for 6 arguments', () {
+      var count = 0;
+      var func = imemo6((int a, int b, int c, int d, int e, int f) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, 6), 2);
+      expect(func(null, null, null, null, 5, 6), 3);
+      expect(func(null, null, null, 4, 5, 6), 4);
+      expect(func(null, null, 3, 4, 5, 6), 5);
+      expect(func(null, 2, 3, 4, 5, 6), 6);
+      expect(func(1, 2, 3, 4, 5, 6), 7);
+      expect(func(1, 2, 3, 4, 5, 6), 7);
+    });
+
+    test('should return result for 6 arguments', () {
+      var func = imemo6(
+          (int a, int b, int c, int d, int e, int f) => a + b + c + d + e + f);
+
+      expect(func(1, 1, 1, 1, 1, 1), 6);
+      expect(func(1, 1, 1, 1, 1, 2), 7);
+      expect(func(1, 1, 1, 1, 2, 2), 8);
+      expect(func(1, 1, 1, 2, 2, 2), 9);
+      expect(func(1, 1, 2, 2, 2, 2), 10);
+      expect(func(1, 2, 2, 2, 2, 2), 11);
+      expect(func(2, 2, 2, 2, 2, 2), 12);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo6((Rectangle<int> a, Rectangle<int> b, Rectangle<int> c,
+              Rectangle<int> d, Rectangle<int> e, Rectangle<int> f) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect6), 2);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1), 3);
+      expect(func(rect1, rect3, rect3, rect4, rect3, rect3), 4);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect4), 5);
+      expect(func(rect2, rect2, rect3, rect1, rect1, rect1), 6);
+      expect(func(rect1, rect2, rect3, rect4, rect1, rect5), 7);
+      expect(func(rect4, rect2, rect3, rect5, rect2, rect7), 8);
+      expect(func(rect1, rect2, rect3, rect5, rect2, rect7), 9);
+      expect(func(rect1, rect2, rect3, rect5, rect2, rect7), 9);
+    });
+  });
+
+  group('memo7', () {
+    test('should cache result for 7 arguments', () {
+      var count = 0;
+      var func =
+          memo7((int a, int b, int c, int d, int e, int f, int g) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, 7), 2);
+      expect(func(null, null, null, null, null, 6, 7), 3);
+      expect(func(null, null, null, null, 5, 6, 7), 4);
+      expect(func(null, null, null, 4, 5, 6, 7), 5);
+      expect(func(null, null, 3, 4, 5, 6, 7), 6);
+      expect(func(null, 2, 3, 4, 5, 6, 7), 7);
+      expect(func(1, 2, 3, 4, 5, 6, 7), 8);
+      expect(func(1, 2, 3, 4, 5, 6, 7), 8);
+    });
+
+    test('should return result for 7 arguments', () {
+      var func = memo7((int a, int b, int c, int d, int e, int f, int g) =>
+          a + b + c + d + e + f + g);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1), 7);
+      expect(func(1, 1, 1, 1, 1, 1, 1), 7);
+      expect(func(1, 1, 1, 1, 1, 1, 2), 8);
+      expect(func(1, 1, 1, 1, 1, 2, 2), 9);
+      expect(func(1, 1, 1, 1, 2, 2, 2), 10);
+      expect(func(1, 1, 1, 2, 2, 2, 2), 11);
+      expect(func(1, 1, 2, 2, 2, 2, 2), 12);
+      expect(func(1, 2, 2, 2, 2, 2, 2), 13);
+      expect(func(2, 2, 2, 2, 2, 2, 2), 14);
+      expect(func(2, 2, 2, 2, 2, 2, 2), 14);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo7((Rectangle<int> a,
+              Rectangle<int> b,
+              Rectangle<int> c,
+              Rectangle<int> d,
+              Rectangle<int> e,
+              Rectangle<int> f,
+              Rectangle<int> g) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect6, rect8), 2);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect4, rect8), 2);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4), 3);
+    });
+  });
+
+  group('imemo7', () {
+    test('should cache result for 7 arguments', () {
+      var count = 0;
+      var func =
+          imemo7((int a, int b, int c, int d, int e, int f, int g) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, 7), 2);
+      expect(func(null, null, null, null, null, 6, 7), 3);
+      expect(func(null, null, null, null, 5, 6, 7), 4);
+      expect(func(null, null, null, 4, 5, 6, 7), 5);
+      expect(func(null, null, 3, 4, 5, 6, 7), 6);
+      expect(func(null, 2, 3, 4, 5, 6, 7), 7);
+      expect(func(1, 2, 3, 4, 5, 6, 7), 8);
+      expect(func(1, 2, 3, 4, 5, 6, 7), 8);
+    });
+
+    test('should return result for 7 arguments', () {
+      var func = imemo7((int a, int b, int c, int d, int e, int f, int g) =>
+          a + b + c + d + e + f + g);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1), 7);
+      expect(func(1, 1, 1, 1, 1, 1, 1), 7);
+      expect(func(1, 1, 1, 1, 1, 1, 2), 8);
+      expect(func(1, 1, 1, 1, 1, 2, 2), 9);
+      expect(func(1, 1, 1, 1, 2, 2, 2), 10);
+      expect(func(1, 1, 1, 2, 2, 2, 2), 11);
+      expect(func(1, 1, 2, 2, 2, 2, 2), 12);
+      expect(func(1, 2, 2, 2, 2, 2, 2), 13);
+      expect(func(2, 2, 2, 2, 2, 2, 2), 14);
+      expect(func(2, 2, 2, 2, 2, 2, 2), 14);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo7((Rectangle<int> a,
+              Rectangle<int> b,
+              Rectangle<int> c,
+              Rectangle<int> d,
+              Rectangle<int> e,
+              Rectangle<int> f,
+              Rectangle<int> g) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7), 1);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect6, rect8), 2);
+      expect(func(rect1, rect2, rect3, rect4, rect4, rect4, rect8), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7), 4);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4), 5);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4), 5);
+    });
+  });
+
+  group('memo8', () {
+    test('should cache result for 8 arguments', () {
+      var count = 0;
+      var func =
+          memo8((int a, int b, int c, int d, int e, int f, int g, int h) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, 8), 2);
+      expect(func(null, null, null, null, null, null, 7, 8), 3);
+      expect(func(null, null, null, null, null, 6, 7, 8), 4);
+      expect(func(null, null, null, null, 5, 6, 7, 8), 5);
+      expect(func(null, null, null, 4, 5, 6, 7, 8), 6);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8), 7);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8), 8);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8), 9);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8), 9);
+    });
+
+    test('should return result for 8 arguments', () {
+      var func = memo8((int a, int b, int c, int d, int e, int f, int g, int h) =>
+          a + b + c + d + e + f + g + h);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1), 8);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1), 8);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2), 10);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2), 11);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2), 12);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2), 13);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2), 14);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2), 15);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2), 16);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo8((Rectangle<int> a,
+              Rectangle<int> b,
+              Rectangle<int> c,
+              Rectangle<int> d,
+              Rectangle<int> e,
+              Rectangle<int> f,
+              Rectangle<int> g,
+              Rectangle<int> h) =>
+          ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8), 1);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9), 2);
+      expect(func(rect1, rect2, rect3, rect1, rect4, rect4, rect4, rect9), 2);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1), 3);
+    });
+  });
+
+  group('imemo8', () {
+    test('should cache result for 8 arguments', () {
+      var count = 0;
+      var func =
+      imemo8((int a, int b, int c, int d, int e, int f, int g, int h) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, 8), 2);
+      expect(func(null, null, null, null, null, null, 7, 8), 3);
+      expect(func(null, null, null, null, null, 6, 7, 8), 4);
+      expect(func(null, null, null, null, 5, 6, 7, 8), 5);
+      expect(func(null, null, null, 4, 5, 6, 7, 8), 6);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8), 7);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8), 8);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8), 9);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8), 9);
+    });
+
+    test('should return result for 8 arguments', () {
+      var func = imemo8((int a, int b, int c, int d, int e, int f, int g, int h) =>
+      a + b + c + d + e + f + g + h);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1), 8);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1), 8);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2), 10);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2), 11);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2), 12);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2), 13);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2), 14);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2), 15);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2), 16);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo8((Rectangle<int> a,
+          Rectangle<int> b,
+          Rectangle<int> c,
+          Rectangle<int> d,
+          Rectangle<int> e,
+          Rectangle<int> f,
+          Rectangle<int> g,
+          Rectangle<int> h) =>
+      ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8), 2);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9), 3);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1), 4);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1), 5);
+    });
+  });
+
+  group('memo9', () {
+    test('should cache result for 9 arguments', () {
+      var count = 0;
+      var func =
+      memo9((int a, int b, int c, int d, int e, int f, int g, int h, int i) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, 9), 2);
+      expect(func(null, null, null, null, null, null, null, 8, 9), 3);
+      expect(func(null, null, null, null, null, null, 7, 8, 9), 4);
+      expect(func(null, null, null, null, null, 6, 7, 8, 9), 5);
+      expect(func(null, null, null, null, 5, 6, 7, 8, 9), 6);
+      expect(func(null, null, null, 4, 5, 6, 7, 8, 9), 7);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8, 9), 8);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8, 9), 9);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9), 10);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9), 10);
+    });
+
+    test('should return result for 9 arguments', () {
+      var func = memo9((int a, int b, int c, int d, int e, int f, int g, int h, int i) =>
+      a + b + c + d + e + f + g + h + i);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 2), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2, 2), 11);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2, 2), 12);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2, 2), 13);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2, 2), 14);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2, 2), 15);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2, 2), 17);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo9((Rectangle<int> a,
+          Rectangle<int> b,
+          Rectangle<int> c,
+          Rectangle<int> d,
+          Rectangle<int> e,
+          Rectangle<int> f,
+          Rectangle<int> g,
+          Rectangle<int> h,
+          Rectangle<int> i) =>
+      ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 0, 10, 20);
+      var rect10 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8, rect9), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8, rect9), 1);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9, rect10), 2);
+      expect(func(rect1, rect2, rect3, rect1, rect4, rect4, rect4, rect9, rect10), 2);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1, rect1), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1, rect2), 3);
+    });
+  });
+
+  group('imemo9', () {
+    test('should cache result for 9 arguments', () {
+      var count = 0;
+      var func =
+      imemo9((int a, int b, int c, int d, int e, int f, int g, int h, int i) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, 9), 2);
+      expect(func(null, null, null, null, null, null, null, 8, 9), 3);
+      expect(func(null, null, null, null, null, null, 7, 8, 9), 4);
+      expect(func(null, null, null, null, null, 6, 7, 8, 9), 5);
+      expect(func(null, null, null, null, 5, 6, 7, 8, 9), 6);
+      expect(func(null, null, null, 4, 5, 6, 7, 8, 9), 7);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8, 9), 8);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8, 9), 9);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9), 10);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9), 10);
+    });
+
+    test('should return result for 9 arguments', () {
+      var func = imemo9((int a, int b, int c, int d, int e, int f, int g, int h, int i) =>
+      a + b + c + d + e + f + g + h + i);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1), 9);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 2), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2, 2), 11);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2, 2), 12);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2, 2), 13);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2, 2), 14);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2, 2), 15);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2, 2), 17);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo9((Rectangle<int> a,
+          Rectangle<int> b,
+          Rectangle<int> c,
+          Rectangle<int> d,
+          Rectangle<int> e,
+          Rectangle<int> f,
+          Rectangle<int> g,
+          Rectangle<int> h,
+          Rectangle<int> i) =>
+      ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 0, 10, 20);
+      var rect10 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8, rect9), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8, rect9), 2);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9, rect10), 3);
+      expect(func(rect1, rect2, rect3, rect1, rect4, rect4, rect4, rect9, rect10), 4);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1, rect1), 5);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1, rect2), 6);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1, rect2), 6);
+    });
+  });
+
+  group('memo10', () {
+    test('should cache result for 10 arguments', () {
+      var count = 0;
+      var func =
+      memo10((int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null, 10), 2);
+      expect(func(null, null, null, null, null, null, null, null, 9, 10), 3);
+      expect(func(null, null, null, null, null, null, null, 8, 9, 10), 4);
+      expect(func(null, null, null, null, null, null, 7, 8, 9, 10), 5);
+      expect(func(null, null, null, null, null, 6, 7, 8, 9, 10), 6);
+      expect(func(null, null, null, null, 5, 6, 7, 8, 9, 10), 7);
+      expect(func(null, null, null, 4, 5, 6, 7, 8, 9, 10), 8);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8, 9, 10), 9);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8, 9, 10), 10);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 11);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 11);
+    });
+
+    test('should return result for 10 arguments', () {
+      var func = memo10((int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) =>
+      a + b + c + d + e + f + g + h + i + j);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 2), 11);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 2, 2), 12);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2, 2, 2), 13);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2, 2, 2), 14);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2, 2, 2), 15);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2, 2, 2), 17);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2, 2, 2), 19);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), 20);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), 20);
+    });
+
+    test('should check arguments by value', () {
+      var count = 0;
+      var func = memo10((Rectangle<int> a,
+          Rectangle<int> b,
+          Rectangle<int> c,
+          Rectangle<int> d,
+          Rectangle<int> e,
+          Rectangle<int> f,
+          Rectangle<int> g,
+          Rectangle<int> h,
+          Rectangle<int> i,
+          Rectangle<int> j) =>
+      ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 0, 10, 20);
+      var rect10 = new Rectangle<int>(0, 0, 10, 20);
+      var rect11 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8, rect9, rect10), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8, rect9, rect10), 1);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9, rect10, rect11), 2);
+      expect(func(rect1, rect2, rect3, rect1, rect4, rect4, rect4, rect9, rect10, rect11), 2);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1, rect1, rect10), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1, rect2, rect10), 3);
+    });
+  });
+
+  group('imemo10', () {
+    test('should cache result for 10 arguments', () {
+      var count = 0;
+      var func =
+      imemo10((int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) => ++count);
+
+      expect(count, 0);
+      expect(func(null, null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null, null), 1);
+      expect(func(null, null, null, null, null, null, null, null, null, 10), 2);
+      expect(func(null, null, null, null, null, null, null, null, 9, 10), 3);
+      expect(func(null, null, null, null, null, null, null, 8, 9, 10), 4);
+      expect(func(null, null, null, null, null, null, 7, 8, 9, 10), 5);
+      expect(func(null, null, null, null, null, 6, 7, 8, 9, 10), 6);
+      expect(func(null, null, null, null, 5, 6, 7, 8, 9, 10), 7);
+      expect(func(null, null, null, 4, 5, 6, 7, 8, 9, 10), 8);
+      expect(func(null, null, 3, 4, 5, 6, 7, 8, 9, 10), 9);
+      expect(func(null, 2, 3, 4, 5, 6, 7, 8, 9, 10), 10);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 11);
+      expect(func(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 11);
+    });
+
+    test('should return result for 10 arguments', () {
+      var func = imemo10((int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) =>
+      a + b + c + d + e + f + g + h + i + j);
+
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 10);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 1, 2), 11);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 1, 2, 2), 12);
+      expect(func(1, 1, 1, 1, 1, 1, 1, 2, 2, 2), 13);
+      expect(func(1, 1, 1, 1, 1, 1, 2, 2, 2, 2), 14);
+      expect(func(1, 1, 1, 1, 1, 2, 2, 2, 2, 2), 15);
+      expect(func(1, 1, 1, 1, 2, 2, 2, 2, 2, 2), 16);
+      expect(func(1, 1, 1, 2, 2, 2, 2, 2, 2, 2), 17);
+      expect(func(1, 1, 2, 2, 2, 2, 2, 2, 2, 2), 18);
+      expect(func(1, 2, 2, 2, 2, 2, 2, 2, 2, 2), 19);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), 20);
+      expect(func(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), 20);
+    });
+
+    test('should check arguments by reference', () {
+      var count = 0;
+      var func = imemo10((Rectangle<int> a,
+          Rectangle<int> b,
+          Rectangle<int> c,
+          Rectangle<int> d,
+          Rectangle<int> e,
+          Rectangle<int> f,
+          Rectangle<int> g,
+          Rectangle<int> h,
+          Rectangle<int> i,
+          Rectangle<int> j) =>
+      ++count);
+
+      var rect1 = new Rectangle<int>(0, 0, 10, 20);
+      var rect2 = new Rectangle<int>(0, 0, 10, 20);
+      var rect3 = new Rectangle<int>(0, 0, 10, 20);
+      var rect4 = new Rectangle<int>(0, 0, 10, 20);
+      var rect5 = new Rectangle<int>(0, 0, 10, 20);
+      var rect6 = new Rectangle<int>(0, 0, 10, 20);
+      var rect7 = new Rectangle<int>(0, 0, 10, 20);
+      var rect8 = new Rectangle<int>(0, 0, 10, 20);
+      var rect9 = new Rectangle<int>(0, 0, 10, 20);
+      var rect10 = new Rectangle<int>(0, 0, 10, 20);
+      var rect11 = new Rectangle<int>(0, 5, 10, 20);
+
+      expect(count, 0);
+      expect(func(rect1, rect2, rect3, rect4, rect5, rect6, rect7, rect8, rect9, rect10), 1);
+      expect(func(rect1, rect1, rect3, rect4, rect5, rect1, rect7, rect8, rect9, rect10), 2);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9, rect10, rect11), 3);
+      expect(func(rect1, rect2, rect2, rect4, rect4, rect6, rect8, rect9, rect10, rect11), 3);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect7, rect1, rect1, rect10), 4);
+      expect(func(rect2, rect2, rect3, rect3, rect6, rect1, rect4, rect1, rect2, rect10), 5);
     });
   });
 }


### PR DESCRIPTION
Hey hey :) Cool library, thanks for making it available!

I needed some memoize functions, but was hoping to support the full range of `Func1-Func10`. Therefore, I needed memoizing functions that could handle that range, and figured I'd contribute to this lib since it's already out there :)

Changes:

  - Added memo5-memo10 & imemo5-imemo10
  - Added tests for these new functions
  - Updated readme
  - Bump `func` dependency to 1.0.
  - dartfmt and small code changes for clarity when dealing with Func7+ (mapping numbers mentally to letters became more cumbersome for me at 7+ arguments from what I found, so I just made everything `argA` `argB` etc instead of `arg1` `arg2`).